### PR TITLE
RSDK-10981 Avoid grabbing lock when getting agent in gather

### DIFF
--- a/icegatherer.go
+++ b/icegatherer.go
@@ -11,9 +11,9 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/viamrobotics/ice/v2"
 	"github.com/pion/logging"
 	"github.com/pion/stun"
+	"github.com/viamrobotics/ice/v2"
 )
 
 // ICEGatherer gathers local host, server reflexive and relay
@@ -28,7 +28,7 @@ type ICEGatherer struct {
 	validatedServers []*stun.URI
 	gatherPolicy     ICETransportPolicy
 
-	agent *ice.Agent
+	agent atomic.Pointer[ice.Agent]
 
 	onLocalCandidateHandler atomic.Value // func(candidate *ICECandidate)
 	onStateChangeHandler    atomic.Value // func(state ICEGathererState)
@@ -67,7 +67,7 @@ func (g *ICEGatherer) createAgent() error {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
-	if g.agent != nil || g.State() != ICEGathererStateNew {
+	if g.agent.Load() != nil || g.State() != ICEGathererStateNew {
 		return nil
 	}
 
@@ -140,7 +140,7 @@ func (g *ICEGatherer) createAgent() error {
 		return err
 	}
 
-	g.agent = agent
+	g.agent.Store(agent)
 	return nil
 }
 
@@ -150,7 +150,7 @@ func (g *ICEGatherer) Gather() error {
 		return err
 	}
 
-	agent := g.getAgent()
+	agent := g.agent.Load()
 	// it is possible agent had just been closed
 	if agent == nil {
 		return fmt.Errorf("%w: unable to gather", errICEAgentNotExist)
@@ -203,20 +203,21 @@ func (g *ICEGatherer) close(shouldGracefullyClose bool) error {
 	g.lock.Lock()
 	defer g.lock.Unlock()
 
-	if g.agent == nil {
+	agent := g.agent.Load()
+	if agent == nil {
 		return nil
 	}
 	if shouldGracefullyClose {
-		if err := g.agent.GracefulClose(); err != nil {
+		if err := agent.GracefulClose(); err != nil {
 			return err
 		}
 	} else {
-		if err := g.agent.Close(); err != nil {
+		if err := agent.Close(); err != nil {
 			return err
 		}
 	}
 
-	g.agent = nil
+	g.agent.Store(nil)
 	g.setState(ICEGathererStateClosed)
 
 	return nil
@@ -228,7 +229,7 @@ func (g *ICEGatherer) GetLocalParameters() (ICEParameters, error) {
 		return ICEParameters{}, err
 	}
 
-	agent := g.getAgent()
+	agent := g.agent.Load()
 	// it is possible agent had just been closed
 	if agent == nil {
 		return ICEParameters{}, fmt.Errorf("%w: unable to get local parameters", errICEAgentNotExist)
@@ -252,7 +253,7 @@ func (g *ICEGatherer) GetLocalCandidates() ([]ICECandidate, error) {
 		return nil, err
 	}
 
-	agent := g.getAgent()
+	agent := g.agent.Load()
 	// it is possible agent had just been closed
 	if agent == nil {
 		return nil, fmt.Errorf("%w: unable to get local candidates", errICEAgentNotExist)
@@ -290,14 +291,8 @@ func (g *ICEGatherer) setState(s ICEGathererState) {
 	}
 }
 
-func (g *ICEGatherer) getAgent() *ice.Agent {
-	g.lock.RLock()
-	defer g.lock.RUnlock()
-	return g.agent
-}
-
 func (g *ICEGatherer) collectStats(collector *statsReportCollector) {
-	agent := g.getAgent()
+	agent := g.agent.Load()
 	if agent == nil {
 		return
 	}

--- a/icetransport.go
+++ b/icetransport.go
@@ -13,8 +13,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/viamrobotics/ice/v2"
 	"github.com/pion/logging"
+	"github.com/viamrobotics/ice/v2"
 	"github.com/viamrobotics/webrtc/v3/internal/mux"
 	"github.com/viamrobotics/webrtc/v3/internal/util"
 )
@@ -47,7 +47,7 @@ type ICETransport struct {
 // GetSelectedCandidatePair returns the selected candidate pair on which packets are sent
 // if there is no selected pair nil is returned
 func (t *ICETransport) GetSelectedCandidatePair() (*ICECandidatePair, error) {
-	agent := t.gatherer.getAgent()
+	agent := t.gatherer.agent.Load()
 	if agent == nil {
 		return nil, nil //nolint:nilnil
 	}
@@ -98,7 +98,7 @@ func (t *ICETransport) Start(gatherer *ICEGatherer, params ICEParameters, role *
 		return err
 	}
 
-	agent := t.gatherer.getAgent()
+	agent := t.gatherer.agent.Load()
 	if agent == nil {
 		return fmt.Errorf("%w: unable to start ICETransport", errICEAgentNotExist)
 	}
@@ -179,7 +179,7 @@ func (t *ICETransport) restart() error {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	agent := t.gatherer.getAgent()
+	agent := t.gatherer.agent.Load()
 	if agent == nil {
 		return fmt.Errorf("%w: unable to restart ICETransport", errICEAgentNotExist)
 	}
@@ -277,7 +277,7 @@ func (t *ICETransport) SetRemoteCandidates(remoteCandidates []ICECandidate) erro
 		return err
 	}
 
-	agent := t.gatherer.getAgent()
+	agent := t.gatherer.agent.Load()
 	if agent == nil {
 		return fmt.Errorf("%w: unable to set remote candidates", errICEAgentNotExist)
 	}
@@ -316,7 +316,7 @@ func (t *ICETransport) AddRemoteCandidate(remoteCandidate *ICECandidate) error {
 		}
 	}
 
-	agent := t.gatherer.getAgent()
+	agent := t.gatherer.agent.Load()
 	if agent == nil {
 		return fmt.Errorf("%w: unable to add remote candidates", errICEAgentNotExist)
 	}
@@ -355,7 +355,7 @@ func (t *ICETransport) newEndpoint(f mux.MatchFunc) *mux.Endpoint {
 func (t *ICETransport) ensureGatherer() error {
 	if t.gatherer == nil {
 		return errICEGathererNotStarted
-	} else if t.gatherer.getAgent() == nil {
+	} else if t.gatherer.agent.Load() == nil {
 		if err := t.gatherer.createAgent(); err != nil {
 			return err
 		}
@@ -389,7 +389,7 @@ func (t *ICETransport) haveRemoteCredentialsChange(newUfrag, newPwd string) bool
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	agent := t.gatherer.getAgent()
+	agent := t.gatherer.agent.Load()
 	if agent == nil {
 		return false
 	}
@@ -406,7 +406,7 @@ func (t *ICETransport) setRemoteCredentials(newUfrag, newPwd string) error {
 	t.lock.Lock()
 	defer t.lock.Unlock()
 
-	agent := t.gatherer.getAgent()
+	agent := t.gatherer.agent.Load()
 	if agent == nil {
 		return fmt.Errorf("%w: unable to SetRemoteCredentials", errICEAgentNotExist)
 	}


### PR DESCRIPTION
Makes `agent` an atomic pointer instead of grabbing an `RLock()` every time we want to access it. Stops our pion callbacks from accidentally deadlocking with notifier `GracefulClose` (has a `Wait`) that has `Lock()`ed when we do stuff like `GetSelectedCandidatePair`.